### PR TITLE
GetTokens updated (password never leaves machine)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@aws-sdk/client-cognito-identity": "^3.348.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.332.0",
     "@jest/globals": "^29.5.0",
+    "amazon-cognito-identity-js": "^6.2.0",
     "aws-sdk": "^2.1379.0",
     "commander": "^11.0.0",
     "dotenv": "^16.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scribelabsai/auth",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Library to connect to Scribe's platform.",
   "type": "module",
   "main": "./dist/index.js",

--- a/tests/scribeAuth.test.ts
+++ b/tests/scribeAuth.test.ts
@@ -11,11 +11,12 @@ const username = process.env['USER']!;
 const password = process.env['PASSWORD']!;
 const password2 = process.env['PASSWORD2']!;
 const userPoolId = process.env['USER_POOL_ID']!;
+const userPoolId2 = process.env['USER_POOL_ID2']!;
 const federatedPoolId = process.env['FEDERATED_POOL_ID']!;
-const access = new Auth(clientId);
+const access = new Auth({ clientId, userPoolId });
 const poolAccess = new Auth({
   clientId: clientId2,
-  userPoolId: userPoolId,
+  userPoolId: userPoolId2,
   identityPoolId: federatedPoolId,
 });
 
@@ -59,6 +60,11 @@ describe('Federated Credentials', () => {
   });
   test('Get federated id fails', async () => {
     await expect(poolAccess.getFederatedId('idToken')).rejects.toThrow();
+  });
+  test('Get federated id with NO identityPoolId fails', async () => {
+    const tokens = await access.getTokens({ username, password });
+    const idToken = tokens.idToken;
+    await expect(access.getFederatedId(idToken)).rejects.toThrow();
   });
 
   test('Get credentials passes', async () => {


### PR DESCRIPTION
**DONE**

- When using _getTokens_ the password never leaves the machine
- Auth class structure updated:
  - _fedClient_ created only when _identityPoolId_ is passed
  - _clientId_ and _userPoolId_ are mandatory
- Tests updated